### PR TITLE
feat: add web_fetch tool for fetching URL content

### DIFF
--- a/src/durable-objects/ChatSession.ts
+++ b/src/durable-objects/ChatSession.ts
@@ -17,6 +17,7 @@ import type { Model } from '../lib/pi-ai/types'
 import { createBashInstance, createBashTool } from '../lib/tools/bash'
 import { createEditTool, createListTool, createReadTool, createWriteTool } from '../lib/tools/file-tools'
 import { createListMountsTool, createMountTool, createUnmountTool } from '../lib/tools/mount-tools'
+import { createWebFetchTool } from '../lib/tools/web-fetch'
 
 interface Env {
   DB: D1Database
@@ -227,6 +228,12 @@ You have access to the following tools:
 - unmount: Remove the mounted repository
 - list_mounts: List the currently mounted repository
 
+**Web Fetch:**
+- web_fetch: Fetch content from a URL and return it as text
+  - Converts HTML to markdown/text automatically
+  - Supports an optional prompt to describe what to extract
+  - HTTP URLs are automatically upgraded to HTTPS
+
 All file operations work with the shared filesystem. The filesystem starts at /work as the working directory.
 
 **File Persistence:**
@@ -257,7 +264,11 @@ Use 'ls /mnt' or list with path="/mnt" to see mounted repositories.
 4. Modify a file: edit({ path: "/mnt/git/README.md", oldText: "...", newText: "..." })
 5. Stage and commit: bash({ command: "cd /mnt/git && git add . && git commit -m 'Fix typo'" })
 6. Push to remote: bash({ command: "cd /mnt/git && git push" })
-7. Create a PR: bash({ command: "cd /mnt/git && gh pr create --title 'Fix typo' --body 'Fixed a typo in README'" })`
+7. Create a PR: bash({ command: "cd /mnt/git && gh pr create --title 'Fix typo' --body 'Fixed a typo in README'" })
+
+**Workflow example for fetching web content:**
+1. Fetch a webpage: web_fetch({ url: "https://example.com/docs" })
+2. Fetch with extraction prompt: web_fetch({ url: "https://api.example.com/status", prompt: "Extract the current status and any error messages" })`
   }
 
   /**
@@ -309,6 +320,9 @@ Use 'ls /mnt' or list with path="/mnt" to see mounted repositories.
       const unmountTool = createUnmountTool(mountToolOptions)
       const listMountsTool = createListMountsTool(mountToolOptions)
 
+      // Create web fetch tool
+      const webFetchTool = createWebFetchTool()
+
       // Determine which messages to use:
       // - If contextMessages provided (e.g., from Slack thread), use those
       // - Otherwise use stored session messages
@@ -326,7 +340,7 @@ Use 'ls /mnt' or list with path="/mnt" to see mounted repositories.
         initialState: {
           model: modelConfig,
           systemPrompt: finalSystemPrompt,
-          tools: [readTool, writeTool, editTool, listTool, bashTool, mountTool, unmountTool, listMountsTool],
+          tools: [readTool, writeTool, editTool, listTool, bashTool, mountTool, unmountTool, listMountsTool, webFetchTool],
           messages: initialMessages,
         },
         getApiKey: async () => apiKey,

--- a/src/lib/tools/web-fetch.ts
+++ b/src/lib/tools/web-fetch.ts
@@ -1,0 +1,228 @@
+import { Type, type Static } from '@sinclair/typebox'
+import type { AgentTool } from '../pi-agent/types'
+
+// ============================================================================
+// WebFetch Tool
+// ============================================================================
+const webFetchSchema = Type.Object({
+  url: Type.String({
+    description: 'The URL to fetch content from (must be a valid HTTP/HTTPS URL)'
+  }),
+  prompt: Type.Optional(Type.String({
+    description: 'Optional prompt to describe what information to extract from the page. If not provided, returns the full content.'
+  })),
+})
+
+/**
+ * Convert HTML to plain text/markdown
+ * Strips tags but preserves structure
+ */
+function htmlToText(html: string): string {
+  let text = html
+
+  // Remove script and style tags with their content
+  text = text.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
+  text = text.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
+  text = text.replace(/<noscript[^>]*>[\s\S]*?<\/noscript>/gi, '')
+
+  // Convert common block elements to newlines
+  text = text.replace(/<\/?(div|p|br|hr|h[1-6]|ul|ol|li|table|tr|th|td|blockquote|pre|article|section|header|footer|nav|aside)[^>]*>/gi, '\n')
+
+  // Convert links to markdown style
+  text = text.replace(/<a[^>]*href="([^"]*)"[^>]*>([^<]*)<\/a>/gi, '[$2]($1)')
+
+  // Convert bold/strong
+  text = text.replace(/<(b|strong)[^>]*>([^<]*)<\/(b|strong)>/gi, '**$2**')
+
+  // Convert italic/em
+  text = text.replace(/<(i|em)[^>]*>([^<]*)<\/(i|em)>/gi, '*$2*')
+
+  // Convert code
+  text = text.replace(/<code[^>]*>([^<]*)<\/code>/gi, '`$1`')
+
+  // Remove all remaining HTML tags
+  text = text.replace(/<[^>]+>/g, '')
+
+  // Decode common HTML entities
+  text = text.replace(/&nbsp;/g, ' ')
+  text = text.replace(/&amp;/g, '&')
+  text = text.replace(/&lt;/g, '<')
+  text = text.replace(/&gt;/g, '>')
+  text = text.replace(/&quot;/g, '"')
+  text = text.replace(/&#39;/g, "'")
+  text = text.replace(/&apos;/g, "'")
+
+  // Clean up whitespace
+  text = text.replace(/\n\s*\n\s*\n/g, '\n\n')  // Max 2 newlines
+  text = text.replace(/[ \t]+/g, ' ')  // Collapse horizontal whitespace
+  text = text.trim()
+
+  return text
+}
+
+/**
+ * Truncate content if too long
+ */
+function truncateContent(content: string, maxLength: number = 50000): string {
+  if (content.length <= maxLength) {
+    return content
+  }
+  return content.slice(0, maxLength) + '\n\n... [Content truncated due to length]'
+}
+
+export function createWebFetchTool(): AgentTool<typeof webFetchSchema> {
+  return {
+    label: 'WebFetch',
+    name: 'web_fetch',
+    description: `Fetch content from a URL and return it as text.
+- Takes a URL and an optional prompt as input
+- Fetches the URL content, converts HTML to markdown/text
+- Returns the processed content
+- Use this tool when you need to retrieve and analyze web content
+- HTTP URLs will be automatically upgraded to HTTPS
+- The prompt parameter can describe what information you want to extract`,
+    parameters: webFetchSchema,
+    execute: async (_toolCallId: string, args: Static<typeof webFetchSchema>, signal?: AbortSignal) => {
+      if (signal?.aborted) {
+        throw new Error('Execution aborted')
+      }
+
+      let url = args.url.trim()
+
+      // Validate URL
+      if (!url) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: 'Error: URL is required'
+          }],
+          details: { error: 'URL is required' }
+        }
+      }
+
+      // Upgrade HTTP to HTTPS
+      if (url.startsWith('http://')) {
+        url = url.replace('http://', 'https://')
+      }
+
+      // Ensure URL has protocol
+      if (!url.startsWith('https://')) {
+        url = 'https://' + url
+      }
+
+      try {
+        // Validate URL format
+        new URL(url)
+      } catch {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: `Error: Invalid URL format: ${url}`
+          }],
+          details: { error: 'Invalid URL format', url }
+        }
+      }
+
+      try {
+        // Fetch the URL with a timeout
+        const controller = new AbortController()
+        const timeoutId = setTimeout(() => controller.abort(), 30000) // 30 second timeout
+
+        const response = await fetch(url, {
+          method: 'GET',
+          headers: {
+            'User-Agent': 'Mozilla/5.0 (compatible; WebFetchBot/1.0)',
+            'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,text/plain;q=0.8,*/*;q=0.7',
+            'Accept-Language': 'en-US,en;q=0.9',
+          },
+          signal: signal || controller.signal,
+          redirect: 'follow',
+        })
+
+        clearTimeout(timeoutId)
+
+        if (!response.ok) {
+          return {
+            content: [{
+              type: 'text' as const,
+              text: `Error: HTTP ${response.status} ${response.statusText} when fetching ${url}`
+            }],
+            details: {
+              error: `HTTP ${response.status}`,
+              url,
+              status: response.status,
+              statusText: response.statusText
+            }
+          }
+        }
+
+        const contentType = response.headers.get('content-type') || ''
+        const rawContent = await response.text()
+
+        let processedContent: string
+
+        // Process based on content type
+        if (contentType.includes('text/html') || contentType.includes('application/xhtml')) {
+          processedContent = htmlToText(rawContent)
+        } else if (contentType.includes('application/json')) {
+          try {
+            const json = JSON.parse(rawContent)
+            processedContent = JSON.stringify(json, null, 2)
+          } catch {
+            processedContent = rawContent
+          }
+        } else {
+          // Plain text or other
+          processedContent = rawContent
+        }
+
+        // Truncate if too long
+        processedContent = truncateContent(processedContent)
+
+        // Build response
+        let resultText = `# Content from ${url}\n\n`
+
+        if (args.prompt) {
+          resultText += `**Extraction prompt:** ${args.prompt}\n\n`
+        }
+
+        resultText += processedContent
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: resultText
+          }],
+          details: {
+            url,
+            contentType,
+            originalSize: rawContent.length,
+            processedSize: processedContent.length,
+            prompt: args.prompt
+          }
+        }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error)
+
+        // Check for specific error types
+        if (errorMessage.includes('abort') || errorMessage.includes('timeout')) {
+          return {
+            content: [{
+              type: 'text' as const,
+              text: `Error: Request timed out when fetching ${url}`
+            }],
+            details: { error: 'Request timeout', url }
+          }
+        }
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: `Error fetching URL: ${errorMessage}`
+          }],
+          details: { error: errorMessage, url }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add a new `web_fetch` tool similar to Claude Code's WebFetch tool
- Fetches content from URLs with automatic HTTP to HTTPS upgrade
- Converts HTML to markdown/text for easier processing
- Supports optional prompt parameter for extraction guidance
- Includes 30s timeout and content truncation (50k chars)
- Updated system prompt with tool documentation and examples

## Test plan
- [ ] Test fetching a simple HTML page
- [ ] Test fetching JSON content
- [ ] Test with optional prompt parameter
- [ ] Test timeout handling with slow URLs
- [ ] Test invalid URL handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)