### PR TITLE
feat: display tool calls in chat UI

### DIFF
--- a/src/client/components/ChatMessage.tsx
+++ b/src/client/components/ChatMessage.tsx
@@ -1,11 +1,17 @@
 import React from 'react'
 
+interface ToolCall {
+  name: string
+  args: any
+}
+
 interface ChatMessageProps {
   role: 'user' | 'assistant'
   content: string
+  toolCalls?: ToolCall[]
 }
 
-export function ChatMessage({ role, content }: ChatMessageProps) {
+export function ChatMessage({ role, content, toolCalls }: ChatMessageProps) {
   const formatContent = (text: string) => {
     // Ensure text is a string
     const textStr = typeof text === 'string' ? text : String(text || '')
@@ -17,6 +23,24 @@ export function ChatMessage({ role, content }: ChatMessageProps) {
 
   return (
     <div className={`message ${role}`}>
+      {toolCalls && toolCalls.length > 0 && (
+        <div className="tool-calls">
+          {toolCalls.map((toolCall, idx) => (
+            <div key={idx} className="tool-call">
+              <strong>🔧 {toolCall.name}</strong>
+              <pre style={{
+                background: 'rgba(0,0,0,0.2)',
+                padding: '8px',
+                borderRadius: '4px',
+                fontSize: '0.85em',
+                overflow: 'auto'
+              }}>
+                {JSON.stringify(toolCall.args, null, 2)}
+              </pre>
+            </div>
+          ))}
+        </div>
+      )}
       <div dangerouslySetInnerHTML={{ __html: formatContent(content) }} />
     </div>
   )

--- a/src/durable-objects/ChatSession.ts
+++ b/src/durable-objects/ChatSession.ts
@@ -474,6 +474,29 @@ Use 'ls /mnt' or list with path="/mnt" to see mounted repositories.
       agent.subscribe(async (event) => {
         eventCount++
 
+        // Send tool execution events
+        if (event.type === 'tool_execution_start') {
+          await writer.write(encoder.encode(
+            `data: ${JSON.stringify({
+              type: 'tool_call_start',
+              toolName: event.toolName,
+              toolCallId: event.toolCallId,
+              args: event.args
+            })}\n\n`
+          ))
+        }
+
+        if (event.type === 'tool_execution_end') {
+          await writer.write(encoder.encode(
+            `data: ${JSON.stringify({
+              type: 'tool_call_end',
+              toolName: event.toolName,
+              toolCallId: event.toolCallId,
+              isError: event.isError
+            })}\n\n`
+          ))
+        }
+
         // Extract text from message updates
         if (event.type === 'message_update' && event.message.role === 'assistant') {
           const content = event.message.content


### PR DESCRIPTION
## Summary
- Display tool execution information in assistant messages for better transparency
- Stream tool call events (name and arguments) via SSE to the frontend
- Show tool calls with 🔧 icon and formatted JSON arguments
- Load and display tool calls from conversation history

## Changes
- **Backend** (`ChatSession.ts`): Listen to `tool_execution_start` and `tool_execution_end` events and stream them to frontend
- **Frontend** (`App.tsx`): Handle `tool_call_start` events and track tool calls per message
- **UI Component** (`ChatMessage.tsx`): Render tool calls above message content with formatted arguments

## Test plan
- [ ] Start a new chat session
- [ ] Ask the AI to use a tool (e.g., "read /work/README.md")
- [ ] Verify tool call appears in the UI before the response
- [ ] Refresh the page and verify tool calls are loaded from history
- [ ] Check that multiple tool calls in one turn all display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)