### PR TITLE
fix: improve code block width control

### DIFF
--- a/src/client/components/ChatMessage.tsx
+++ b/src/client/components/ChatMessage.tsx
@@ -16,8 +16,8 @@ export function ChatMessage({ role, content, toolCalls }: ChatMessageProps) {
     // Ensure text is a string
     const textStr = typeof text === 'string' ? text : String(text || '')
     return textStr
-      .replace(/```([\s\S]*?)```/g, '<pre><code>$1</code></pre>')
-      .replace(/`([^`]+)`/g, '<code>$1</code>')
+      .replace(/```([\s\S]*?)```/g, '<pre style="max-width: 100%; overflow-x: auto; white-space: pre-wrap; word-break: break-word;"><code>$1</code></pre>')
+      .replace(/`([^`]+)`/g, '<code style="word-break: break-word;">$1</code>')
       .replace(/\n/g, '<br>')
   }
 
@@ -33,7 +33,11 @@ export function ChatMessage({ role, content, toolCalls }: ChatMessageProps) {
                 padding: '8px',
                 borderRadius: '4px',
                 fontSize: '0.85em',
-                overflow: 'auto'
+                overflow: 'auto',
+                maxWidth: '100%',
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word',
+                margin: '4px 0'
               }}>
                 {JSON.stringify(toolCall.args, null, 2)}
               </pre>


### PR DESCRIPTION
## Summary
Fix code block overflow issues that break page layout by adding proper width constraints and text wrapping.

## Problem
Code blocks were not constrained in width, causing overflow and breaking the page layout when displaying long content.

## Solution
Added CSS properties to all code blocks:
- `max-width: 100%` - Prevent overflow
- `white-space: pre-wrap` - Allow text wrapping
- `word-break: break-word` - Break long strings
- `overflow-x: auto` - Add scrollbar if needed

## Changes
- Updated ChatMessage.tsx with proper styles for both tool call args and markdown code blocks

## Test plan
- [ ] Display tool calls with long arguments
- [ ] Display markdown code blocks with long lines
- [ ] Verify no horizontal page scrolling
- [ ] Check code remains readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)