### PR TITLE
feat: add Slack user display names to messages

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -105,3 +105,18 @@ CREATE TABLE IF NOT EXISTS slack_thread_mapping (
 -- Index for efficient thread lookups
 CREATE INDEX IF NOT EXISTS idx_slack_thread_key ON slack_thread_mapping(thread_key);
 CREATE INDEX IF NOT EXISTS idx_slack_thread_session ON slack_thread_mapping(session_id);
+
+-- Slack users table - caches Slack user information
+CREATE TABLE IF NOT EXISTS slack_users (
+  user_id TEXT NOT NULL,                   -- Slack User ID (e.g., U0XXXXXXX)
+  app_id TEXT NOT NULL,                    -- Slack App ID (for multi-workspace support)
+  name TEXT NOT NULL,                      -- User's display name
+  real_name TEXT,                          -- User's real name (optional)
+  avatar_url TEXT,                         -- User's avatar URL (optional)
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  PRIMARY KEY (user_id, app_id)
+);
+
+-- Index for efficient user lookups
+CREATE INDEX IF NOT EXISTS idx_slack_users_lookup ON slack_users(app_id, user_id);

--- a/src/lib/slack/api.ts
+++ b/src/lib/slack/api.ts
@@ -7,6 +7,7 @@ import type {
   ConversationsRepliesResponse,
   AuthTestResponse,
   ChatPostMessageResponse,
+  UsersInfoResponse,
 } from './types'
 
 const SLACK_API_BASE = 'https://slack.com/api'
@@ -78,6 +79,23 @@ export class SlackClient {
 
     const data = (await response.json()) as AuthTestResponse
     return data.ok ? data.user_id || null : null
+  }
+
+  /**
+   * Get user information
+   */
+  async getUserInfo(userId: string): Promise<UsersInfoResponse> {
+    const url = new URL(`${SLACK_API_BASE}/users.info`)
+    url.searchParams.set('user', userId)
+
+    const response = await fetch(url.toString(), {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${this.botToken}`,
+      },
+    })
+
+    return response.json() as Promise<UsersInfoResponse>
   }
 }
 

--- a/src/lib/slack/thread-history.ts
+++ b/src/lib/slack/thread-history.ts
@@ -36,11 +36,16 @@ export function convertSlackToAgentMessages(
       const isBot = msg.bot_id !== undefined || (botUserId && msg.user === botUserId)
 
       // Clean up the text
-      const text = isBot ? msg.text : stripBotMention(msg.text, botUserId)
+      let text = isBot ? msg.text : stripBotMention(msg.text, botUserId)
 
       // Skip empty messages after stripping mentions
       if (!text) {
         return null
+      }
+
+      // Prepend user name for user messages
+      if (!isBot && msg.user_name) {
+        text = `[user:${msg.user_name}] ${text}`
       }
 
       return {

--- a/src/lib/slack/types.ts
+++ b/src/lib/slack/types.ts
@@ -35,6 +35,7 @@ export type SlackPayload = SlackEventCallback | SlackUrlVerification
 export interface SlackMessage {
   type: string
   user?: string
+  user_name?: string  // User display name (enriched from cache)
   bot_id?: string
   text: string
   ts: string
@@ -61,6 +62,25 @@ export interface ChatPostMessageResponse {
   ok: boolean
   ts?: string
   channel?: string
+  error?: string
+}
+
+export interface SlackUserProfile {
+  display_name?: string
+  real_name?: string
+  image_72?: string
+}
+
+export interface SlackUser {
+  id: string
+  name: string
+  real_name?: string
+  profile?: SlackUserProfile
+}
+
+export interface UsersInfoResponse {
+  ok: boolean
+  user?: SlackUser
   error?: string
 }
 
@@ -97,6 +117,16 @@ export interface SlackThreadMapping {
   channel: string
   thread_ts: string | null
   user_id: string | null
+  created_at: number
+  updated_at: number
+}
+
+export interface SlackUserCache {
+  user_id: string
+  app_id: string
+  name: string
+  real_name: string | null
+  avatar_url: string | null
   created_at: number
   updated_at: number
 }

--- a/src/routes/slack.ts
+++ b/src/routes/slack.ts
@@ -8,6 +8,7 @@ import type {
   SlackAppConfig,
   SlackEvent,
   SlackPayload,
+  SlackUserCache,
 } from '../lib/slack'
 import {
   convertSlackToAgentMessages,
@@ -105,6 +106,84 @@ async function saveThreadMapping(
     .run()
 }
 
+/**
+ * Get user info from cache
+ */
+async function getCachedUserInfo(
+  db: D1Database,
+  appId: string,
+  userId: string
+): Promise<SlackUserCache | null> {
+  const result = await db
+    .prepare('SELECT * FROM slack_users WHERE app_id = ? AND user_id = ?')
+    .bind(appId, userId)
+    .first<SlackUserCache>()
+  return result || null
+}
+
+/**
+ * Save user info to cache
+ */
+async function saveUserInfo(
+  db: D1Database,
+  appId: string,
+  userId: string,
+  name: string,
+  realName: string | null,
+  avatarUrl: string | null
+): Promise<void> {
+  const now = Date.now()
+  await db
+    .prepare(`
+      INSERT INTO slack_users (user_id, app_id, name, real_name, avatar_url, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(user_id, app_id) DO UPDATE SET
+        name = excluded.name,
+        real_name = excluded.real_name,
+        avatar_url = excluded.avatar_url,
+        updated_at = excluded.updated_at
+    `)
+    .bind(userId, appId, name, realName, avatarUrl, now, now)
+    .run()
+}
+
+/**
+ * Get or fetch user info with caching
+ */
+async function getUserInfo(
+  db: D1Database,
+  client: SlackClient,
+  appId: string,
+  userId: string
+): Promise<string> {
+  // Try cache first
+  const cached = await getCachedUserInfo(db, appId, userId)
+  if (cached) {
+    return cached.name
+  }
+
+  // Fetch from Slack API
+  try {
+    const response = await client.getUserInfo(userId)
+    if (response.ok && response.user) {
+      const user = response.user
+      // Priority: display_name > real_name > username
+      const displayName = user.profile?.display_name || user.real_name || user.name
+      const realName = user.real_name || null
+      const avatarUrl = user.profile?.image_72 || null
+
+      // Save to cache
+      await saveUserInfo(db, appId, userId, displayName, realName, avatarUrl)
+      return displayName
+    }
+  } catch (error) {
+    console.error('Failed to fetch user info:', error)
+  }
+
+  // Fallback to user ID if everything fails
+  return userId
+}
+
 // ============================================================================
 // Thread key generation
 // ============================================================================
@@ -193,7 +272,7 @@ async function handleSlackMessage(
     }
 
     // Extract user message from event
-    const userMessage = extractUserMessage(event.text || '', botUserId || undefined)
+    let userMessage = extractUserMessage(event.text || '', botUserId || undefined)
     // Only require a message for new conversations (not replies in threads)
     if (!userMessage && !event.thread_ts) {
       await client.postMessage(
@@ -204,10 +283,24 @@ async function handleSlackMessage(
       return
     }
 
+    // Prepend user name to the current message
+    if (userMessage && event.user) {
+      const userName = await getUserInfo(env.DB, client, appConfig.app_id, event.user)
+      userMessage = `[user:${userName}] ${userMessage}`
+    }
+
     // Get thread history if this is a reply in a thread
     let contextMessages: any[] = []
     if (event.thread_ts) {
       const threadMessages = await client.getThreadReplies(channel, event.thread_ts)
+
+      // Enrich messages with user names
+      for (const msg of threadMessages) {
+        if (msg.user && !msg.bot_id && msg.user !== botUserId) {
+          msg.user_name = await getUserInfo(env.DB, client, appConfig.app_id, msg.user)
+        }
+      }
+
       // Exclude the current message (last one) since we'll add it separately
       const historyMessages = threadMessages.slice(0, -1)
       contextMessages = convertSlackToAgentMessages(historyMessages, botUserId || undefined)


### PR DESCRIPTION
## Summary
Add support for displaying Slack user names in chat messages by implementing user information caching and API integration.

## Changes
- **Database**: Add `slack_users` table to cache user information (user_id, display_name, real_name, avatar_url)
- **Slack API**: Implement `getUserInfo()` method using Slack's `users.info` API
- **Message Format**: Display messages in format `[user:display_name] message text`
- **Caching**: Cache user info in database to reduce API calls
- **Name Priority**: Use display_name > real_name > username (fallback to user ID on error)

## Technical Details
- Added helper functions: `getCachedUserInfo()`, `saveUserInfo()`, `getUserInfo()`
- Enriches both current messages and thread history with user names
- Database schema includes composite primary key (user_id, app_id) for multi-workspace support

## Test plan
- [ ] Deploy to production
- [ ] Test with Slack messages to verify user names display correctly
- [ ] Verify database caching works (subsequent messages don't call API)
- [ ] Test with users who have different name configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)