### PR TITLE
fix: exclude sensitive fields from admin API endpoints

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -27,13 +27,13 @@ admin.get('/llm-configs', async (c) => {
   }
 })
 
-// GET /admin/llm-configs/:name - Get a single LLM config
+// GET /admin/llm-configs/:name - Get a single LLM config (excludes api_key for security)
 admin.get('/llm-configs/:name', async (c) => {
   try {
     const name = c.req.param('name')
     const result = await c.env.DB.prepare(
-      'SELECT * FROM llm_configs WHERE name = ?'
-    ).bind(name).first<LLMConfig>()
+      'SELECT name, provider, base_url, model, created_at, updated_at FROM llm_configs WHERE name = ?'
+    ).bind(name).first<Omit<LLMConfig, 'api_key'>>()
 
     if (!result) {
       return c.json({ error: 'Config not found' }, 404)
@@ -184,13 +184,15 @@ admin.get('/slack-apps', async (c) => {
   }
 })
 
-// GET /admin/slack-apps/:appId - Get a single Slack app
+// GET /admin/slack-apps/:appId - Get a single Slack app (excludes sensitive fields for security)
 admin.get('/slack-apps/:appId', async (c) => {
   try {
     const appId = c.req.param('appId')
     const result = await c.env.DB.prepare(
-      'SELECT * FROM slack_apps WHERE app_id = ?'
-    ).bind(appId).first<SlackAppConfig>()
+      `SELECT id, app_id, team_id, app_name, bot_user_id, llm_config_name, system_prompt,
+              created_at, updated_at
+       FROM slack_apps WHERE app_id = ?`
+    ).bind(appId).first<Omit<SlackAppConfig, 'bot_token' | 'signing_secret'>>()
 
     if (!result) {
       return c.json({ error: 'Slack app not found' }, 404)


### PR DESCRIPTION
## Summary
- Remove `api_key` from `GET /api/admin/llm-configs/:name` response
- Remove `bot_token` and `signing_secret` from `GET /api/admin/slack-apps/:appId` response

These sensitive fields were being returned unnecessarily. The frontend uses a "leave blank to keep existing" pattern for credential updates, so it doesn't need to receive the actual values.

## Test plan
- [ ] Verify `GET /api/admin/llm-configs/:name` no longer returns `api_key`
- [ ] Verify `GET /api/admin/slack-apps/:appId` no longer returns `bot_token` or `signing_secret`
- [ ] Verify editing LLM configs still works (leave API key blank to keep existing)
- [ ] Verify editing Slack apps still works (leave tokens blank to keep existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)