### PR TITLE
fix: improve Slack error logging for better debugging

### DIFF
--- a/src/routes/slack.ts
+++ b/src/routes/slack.ts
@@ -432,7 +432,9 @@ async function handleSlackMessage(
     // Send "processing" message first
     const processingMsg = await client.postMessage(channel, 'Processing...', threadTs)
     if (!processingMsg.ok || !processingMsg.ts) {
-      await client.postMessage(channel, 'Error: Failed to send processing message', threadTs)
+      const errorMsg = `Failed to send message: ${(processingMsg as any).error || 'unknown error'}`
+      console.error('Slack postMessage failed:', JSON.stringify(processingMsg))
+      await client.postMessage(channel, `Error: ${errorMsg}`, threadTs)
       return
     }
     const processingTs = processingMsg.ts
@@ -465,6 +467,7 @@ async function handleSlackMessage(
       }
     } catch (error) {
       // If processing fails, update the processing message with error
+      console.error('Error in ChatSession call:', error)
       await client.updateMessage(channel, processingTs, `Error: ${error instanceof Error ? error.message : String(error)}`)
       throw error
     }


### PR DESCRIPTION
## Summary
- Enhanced error handling in Slack message processing to log detailed API responses
- When `postMessage` fails, now logs the full Slack API response (including error codes like `invalid_auth`, `not_in_channel`, etc.)
- Added explicit error logging for ChatSession failures
- Improved error message formatting shown to users

## Context
When debugging Slack message handling issues, the original code only logged generic error messages without the actual Slack API error codes. This made it difficult to diagnose problems like:
- Invalid bot tokens (`invalid_auth`)
- Bot not added to channel (`not_in_channel`)
- Missing OAuth scopes (`missing_scope`)

## Changes
1. Log full JSON response from Slack API when message sending fails
2. Include specific Slack error codes in user-facing error messages
3. Add error logging for ChatSession processing failures

## Test plan
- [x] Tested with invalid bot token - now logs full error response
- [x] Error messages now show specific Slack error codes to users
- [x] Verified existing functionality still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)