### PR TITLE
feat: Multi-bot session isolation in Slack

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -97,6 +97,7 @@ CREATE TABLE IF NOT EXISTS slack_thread_mapping (
   app_id TEXT NOT NULL,                -- Slack App ID that owns this thread
   channel TEXT NOT NULL,               -- Slack channel ID
   thread_ts TEXT,                      -- Thread timestamp (NULL for non-threaded)
+  last_message_ts TEXT,                -- Last processed message timestamp from Slack
   created_at INTEGER NOT NULL,
   updated_at INTEGER NOT NULL
 );

--- a/src/lib/slack/thread-history.ts
+++ b/src/lib/slack/thread-history.ts
@@ -7,16 +7,17 @@ import type { SlackClient } from './api'
 import type { SlackMessage } from './types'
 
 /**
- * Resolve user IDs to user names from Slack messages
- * Collects all <@USERID> mentions and message senders, returns a mapping of userId -> userName
+ * Resolve all user IDs (including bots) to names from Slack messages
+ * Collects all <@USERID> mentions and message senders
+ * Note: Bot messages have a user field (bot's user ID), so getUserInfo works for both users and bots
  * @param messages - Slack messages to scan for user IDs
  * @param db - D1 database for caching
  * @param client - Slack client for API calls
  * @param appId - Slack app ID
- * @param getUserInfoFn - Function to get user info
+ * @param getUserInfoFn - Function to get user info (works for both users and bots)
  * @returns Map of userId to userName
  */
-export async function resolveUserMentionsInMessages(
+export async function resolveAllUserMentionsInMessages(
   messages: SlackMessage[],
   db: D1Database,
   client: SlackClient,
@@ -27,7 +28,7 @@ export async function resolveUserMentionsInMessages(
   const allUserIds = new Set<string>()
 
   for (const msg of messages) {
-    // Collect message sender IDs
+    // Collect message sender IDs (includes bot user IDs)
     if (msg.user) {
       allUserIds.add(msg.user)
     }
@@ -57,41 +58,62 @@ export async function resolveUserMentionsInMessages(
 }
 
 /**
- * Convert Slack user messages to AgentMessage format
- * Assumes all input messages are user messages (not bot messages)
- * Replaces user mentions and sets user prefix using the provided mapping
- * @param slackUserMessages - User messages from conversations.replies API
- * @param userIdToName - Mapping of userId to userName for mention replacement and prefix
+ * Convert Slack messages to AgentMessage format with bot differentiation
+ * Converts messages based on whether they're from current bot, other bots, or users
+ * @param slackMessages - Messages from conversations.replies API
+ * @param currentBotUserId - Current bot's user ID
+ * @param userIdToName - Mapping of userId to userName (includes bot names via their user IDs)
  * @returns Array of AgentMessage objects
  */
-export function convertSlackUserMessagesToAgentMessages(
-  slackUserMessages: SlackMessage[],
+export function convertSlackMessagesToAgentMessages(
+  slackMessages: SlackMessage[],
+  currentBotUserId: string | null,
   userIdToName: Map<string, string>
 ): AgentMessage[] {
   const mentionRegex = /<@([A-Z0-9]+)>/g
 
-  return slackUserMessages
+  return slackMessages
     .filter((msg) => msg.type === 'message' && msg.text?.trim())
     .map((msg) => {
       let text = msg.text.trim()
 
-      // Replace user mentions with resolved names
+      // Replace all mentions with resolved names
       text = text.replace(mentionRegex, (match, userId) => {
         const userName = userIdToName.get(userId)
         return userName ? `@${userName}` : match
       })
 
-      // Set user prefix from mapping (all messages are user messages)
-      const userName = userIdToName.get(msg.user!)
-      const prefix = userName ? `user:${userName}` : undefined
+      // Determine if this is current bot's message
+      const isCurrentBot = msg.user === currentBotUserId
 
-      // Create user message
-      return {
-        role: 'user' as const,
-        content: [{ type: 'text' as const, text }],
-        timestamp: Date.now(),
-        prefix
-      } as AgentMessage
+      if (isCurrentBot) {
+        // Current bot's message - assistant role
+        return {
+          role: 'assistant' as const,
+          content: [{ type: 'text' as const, text }],
+          timestamp: Date.now()
+        } as AgentMessage
+      } else if (msg.bot_id) {
+        // Other bot's message - user role with bot prefix
+        // Use the bot's user ID to get its name
+        const botName = userIdToName.get(msg.user!) || msg.user || 'bot'
+        return {
+          role: 'user' as const,
+          content: [{ type: 'text' as const, text }],
+          timestamp: Date.now(),
+          prefix: `bot:${botName}`
+        } as AgentMessage
+      } else {
+        // Real user message
+        const userName = userIdToName.get(msg.user!)
+        const prefix = userName ? `user:${userName}` : undefined
+        return {
+          role: 'user' as const,
+          content: [{ type: 'text' as const, text }],
+          timestamp: Date.now(),
+          prefix
+        } as AgentMessage
+      }
     })
 }
 


### PR DESCRIPTION
## Summary

Enables multiple Slack bots to maintain independent sessions in the same thread. Each bot now:
- Has its own isolated session (thread key includes `app_id`)
- Sees other bots' messages as User Messages with `bot:BotName` prefix
- Only loads NEW messages since its last reply (timestamp-based tracking)
- Preserves all @mentions for cross-bot awareness

## Key Changes

### Thread Isolation
- **Thread key format**: Changed from `slack:{channel}:{thread_ts}` to `slack:{app_id}:{channel}:{thread_ts}`
- Each bot maintains separate session in same Slack thread

### Message Tracking
- Added `last_message_ts` column to `slack_thread_mapping` table
- Timestamp-based filtering ensures only new messages are loaded as context
- Prevents message duplication in bot context

### Multi-Bot Context
- Other bots' messages appear as User Messages with `prefix: "bot:BotName"`
- User messages have `prefix: "user:UserName"`
- Current bot's messages remain as assistant role
- All @mentions preserved and resolved to names

### Streaming Prefix Cleanup
- LLM responses that echo prefixes are cleaned during streaming
- Handles incomplete prefix tokens across stream chunks
- Waits for complete `[bot:Name]` pattern before processing

## Database Migration

Run the migration to add the new column:

```bash
wrangler d1 execute mob-session --local --file=migrations/001_add_last_message_ts.sql
wrangler d1 execute mob-session --remote --file=migrations/001_add_last_message_ts.sql
```

## Testing

Verified with two bots (Max and Kim) in same Slack thread:
- ✅ Each bot maintains separate session
- ✅ Bots see each other's messages with `bot:Name` prefix
- ✅ No message duplication in context
- ✅ @mentions preserved and resolved correctly
- ✅ Prefix cleaning works in streaming responses

## Technical Details

**Modified Files:**
- [schema.sql](schema.sql) - Added `last_message_ts` column
- [src/routes/slack.ts](src/routes/slack.ts) - Updated thread key and context logic
- [src/lib/slack/thread-history.ts](src/lib/slack/thread-history.ts) - Multi-bot message conversion
- [src/durable-objects/ChatSession.ts](src/durable-objects/ChatSession.ts) - Streaming prefix cleanup
- [README.md](README.md) - Updated documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)