### PR TITLE
fix: Load all thread history when bot joins conversation for first time

### DIFF
--- a/src/routes/slack.ts
+++ b/src/routes/slack.ts
@@ -309,8 +309,15 @@ async function getThreadContext(
         rawContextMessages.push(msg)
       }
     }
+  } else {
+    // No lastMessageTs - this is the bot's first time in this thread
+    // Collect all messages except the current one
+    for (const msg of threadMessages) {
+      if (msg.ts !== currentMessageTs && (msg.user || msg.bot_id)) {
+        rawContextMessages.push(msg)
+      }
+    }
   }
-  // If no lastMessageTs (new thread), contextMessages will be empty - which is correct for first interaction
 
   // Resolve all user IDs (including bots) to names
   const userIdToName = await resolveAllUserMentionsInMessages(


### PR DESCRIPTION
## Problem

When a bot is mentioned for the first time in an existing thread, it was receiving empty context even though there were previous messages in the thread. This happened because:

- `lastMessageTs` is `null` for the bot's first interaction
- The previous logic only loaded messages when `lastMessageTs` existed
- Result: Bot had no awareness of previous conversation

## Fix

Modified [src/routes/slack.ts](src/routes/slack.ts) to handle the `lastMessageTs == null` case:

```typescript
if (lastMessageTs) {
  // Collect messages after lastMessageTs
  for (const msg of threadMessages) {
    if (msg.ts > lastMessageTs && msg.ts !== currentMessageTs && (msg.user || msg.bot_id)) {
      rawContextMessages.push(msg)
    }
  }
} else {
  // No lastMessageTs - this is the bot's first time in this thread
  // Collect all messages except the current one
  for (const msg of threadMessages) {
    if (msg.ts !== currentMessageTs && (msg.user || msg.bot_id)) {
      rawContextMessages.push(msg)
    }
  }
}
```

## Behavior

**Before:**
- Bot1 replies: "Hello"
- Bot2 replies: "Hi"
- User @Bot3: Bot3 sees empty context ❌

**After:**
- Bot1 replies: "Hello"
- Bot2 replies: "Hi"
- User @Bot3: Bot3 sees Bot1 and Bot2's messages ✅

## Testing

Verified in Slack with multi-bot scenario:
1. Kim, Gary, Max replied to thread
2. @Carl (first time in thread)
3. Carl now correctly sees all previous bot messages with `bot:Name` prefixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)